### PR TITLE
fix: update repository name in GitHub Actions workflow

### DIFF
--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   generate:
     runs-on: ubuntu-latest
-    if: github.repository == 'alphaonelabs/alphaonelabs-gsoc' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'alphaonelabs/gsoc' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes the repository name reference in the GitHub Actions workflow configuration. The change updates the conditional check in `.github/workflows/generate-leaderboard.yml` to use the correct repository identifier.

## Changes

**File Modified:**
- `.github/workflows/generate-leaderboard.yml`

**Change Details:**
- Updated the workflow's `if` condition to check `github.repository == 'alphaonelabs/gsoc'` (previously `'alphaonelabs/alphaonelabs-gsoc'`)
- This corrects the repository name reference to match the actual repository namespace
- The `workflow_dispatch` configuration remains unchanged

## Impact

This change ensures the workflow job executes correctly by properly validating against the actual repository name, preventing the job from being skipped due to an incorrect repository reference check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->