### PR TITLE
Update repository references after repo renames & fix leaderboard actions

### DIFF
--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   generate:
     runs-on: ubuntu-latest
-    if: github.repository == 'alphaonelabs/alphaonelabs-gsoc' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'alphaonelabs/gsoc' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout repository

--- a/scripts/generate_leaderboard.py
+++ b/scripts/generate_leaderboard.py
@@ -15,8 +15,8 @@ DEFAULT_OUTPUT_PATH = "data/leaderboard.json"
 # python scripts/generate_leaderboard.py --start-date 2024-09-01 \
 # --end-date 2025-06-01 --output data/leaderboard-2025.json
 REPO_CANDIDATES = [
-    ("alphaonelabs", "alphaonelabs-education-website"),
-    ("AlphaOneLabs", "education-website"),
+    ("alphaonelabs", "website"),
+    ("AlphaOneLabs", "website"),
 ]
 MAX_CLOSED_PAGES = 10
 MAX_OPEN_PAGES = 5


### PR DESCRIPTION
The repository was previously named **`alphaonelabs/alphaonelabs-gsoc`** but has since been renamed to **`alphaonelabs/gsoc`**.

The workflow `generate-leaderboard.yml` still checks against the old repository name:

```yaml
if: github.repository == 'alphaonelabs/alphaonelabs-gsoc'
```

Because of this mismatch, the workflow job is **skipped**, which results in the workflow appearing **grey in GitHub Actions** instead of running/succeeding.

### Fix

I Updated the repository condition to match the current repository name:

```yaml
if: github.repository == 'alphaonelabs/gsoc' || github.event_name == 'workflow_dispatch'
```

This preserves the original intent of restricting execution to the main repository while allowing the workflow to run correctly after the rename.

### Also:

The repository used for fetching pull requests was previously named:
`alphaonelabs/alphaonelabs-education-website`
and has since been renamed to:
`alphaonelabs/website`

The `REPO_CANDIDATES` list has been updated accordingly to ensure the GitHub API queries the correct repository.

### Additional Suggestion (Optional)

The conditional line may not be strictly necessary since the workflow already exists within this repository. Removing it entirely would allow the workflow to run whenever it is triggered without relying on repository name checks.

@A1L13N So do let me know about this should we update the condition only (to `/gsoc`) or should we remove the entire line.



### Result
The workflow should now execute normally and generate the leaderboard data as expected.
